### PR TITLE
Add webrtc-adapter to make Safari happy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandwidth/webrtc-browser-sdk",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -149,6 +149,19 @@
                 "ws": "^5.2.2"
             }
         },
+        "rtcpeerconnection-shim": {
+            "version": "1.2.15",
+            "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+            "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
+            "requires": {
+                "sdp": "^2.6.0"
+            }
+        },
+        "sdp": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+            "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
+        },
         "type-detect": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
@@ -164,6 +177,15 @@
             "version": "3.3.3",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
             "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+        },
+        "webrtc-adapter": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.5.0.tgz",
+            "integrity": "sha512-cUqlw310uLLSYvO8FTNCVmGWSMlMt6vuSDkcYL1nW+RUvAILJ3jEIvAUgFQU5EFGnU+mf9/No14BFv3U+hoxBQ==",
+            "requires": {
+                "rtcpeerconnection-shim": "^1.2.15",
+                "sdp": "^2.12.0"
+            }
         },
         "ws": {
             "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/webrtc-browser-sdk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SDK for Bandwidth WebRTC Browser Applications",
   "main": "dist/index.js",
   "scripts": {
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@types/node": "^12.0.3",
-    "rpc-websockets": "^5.0.9"
+    "rpc-websockets": "^5.0.9",
+    "webrtc-adapter": "^7.5.0"
   }
 }

--- a/src/bandwidthRtc.ts
+++ b/src/bandwidthRtc.ts
@@ -1,3 +1,4 @@
+require("webrtc-adapter");
 import {
   RtcAuthParams,
   RtcOptions,


### PR DESCRIPTION
This fixes https://github.com/Bandwidth/webrtc-browser-sdk/issues/2

For some reason Safari does not generate an SDP offer to receive audio and video unless you first include webrtc-adapter. This is now built into the SDK, so code using the SDK shouldn't have to worry about it going forward.