### PR TITLE
Rename several events and add handling for the 'removed' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,18 @@ Please see the following resources for more information on MediaStreamConstraint
 
 ## Event Listeners
 
+### onUnpublished
+
+- Description: Listens for the unpublished event.
+```javascript
+bandwidthRtc.onUnpublished(event => {
+  console.log(`The stream ${event.streamId} has been unpublished.`);
+});
+```
+
 ### onSubscribe
 
-- Description: Listens for the subscribe event and execute provided callback.
+- Description: Listens for the subscribe event.
 
 ```javascript
 bandwidthRtc.onSubscribe(event => {
@@ -96,13 +105,22 @@ bandwidthRtc.onSubscribe(event => {
 });
 ```
 
-### onUnsubscribe
+### onUnsubscribed
 
-- Descripton: Listens for the unsubscribe event.
+- Descripton: Listens for the unsubscribed event.
 
 ```javascript
-bandwidthRtc.onUnsubscribe(event => {
+bandwidthRtc.onUnsubscribed(event => {
   console.log(`The stream ${event.streamId} has been unsubscribed from.`);
+});
+```
+
+### onRemoved
+
+- Description: Listens for the removed from conference event.
+```javascript
+bandwidth.onRemoved(event => {
+  console.log(`Participant ${event.participantId} has been removed from the conference.`);
 });
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandwidth/webrtc-browser-sdk",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/webrtc-browser-sdk",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "SDK for Bandwidth WebRTC Browser Applications",
   "main": "dist/index.js",
   "scripts": {

--- a/src/bandwidthRtc.ts
+++ b/src/bandwidthRtc.ts
@@ -331,7 +331,7 @@ class BandwidthRtc {
 
   private cleanupRemoteStreams(...streams: string[]) {
     if (streams.length === 0) {
-      streams = Array.from(this.localStreams.keys());
+      streams = Array.from(this.remotePeerConnections.keys());
     }
 
     for (const s of streams) {

--- a/src/bandwidthRtc.ts
+++ b/src/bandwidthRtc.ts
@@ -4,7 +4,7 @@ import {
   RtcOptions,
   OnIceCandidateEvent,
   SubscriptionEvent,
-  UnpublishEvent,
+  UnpublishedEvent,
   MediaType,
   SdpOfferRejectedError,
   MessageReceivedEvent,
@@ -38,8 +38,8 @@ class BandwidthRtc {
   // Event handlers
   subscribedHandler?: { (event: RtcStream): void };
   unsubscribedHandler?: { (event: SubscriptionEvent): void };
-  unpublishedHandler?: { (event: UnpublishEvent): void };
-  conferenceEndedHandler?: { (): void };
+  unpublishedHandler?: { (event: UnpublishedEvent): void };
+  removedHandler?: { (): void };
   messageReceivedHandler?: { (message: MessageReceivedEvent): void };
 
   constructor() {
@@ -59,12 +59,16 @@ class BandwidthRtc {
       this.handleSubscribeEvent.bind(this)
     );
     this.signaling.addListener(
-      "unsubscribe",
-      this.handleUnsubscribeEvent.bind(this)
+      "unsubscribed",
+      this.handleUnsubscribedEvent.bind(this)
     );
     this.signaling.addListener(
-      "unpublish",
-      this.handleUnpublishEvent.bind(this)
+      "unpublished",
+      this.handleUnpublishedEvent.bind(this)
+    );
+    this.signaling.addListener(
+      "removed",
+      this.handleRemovedEvent.bind(this)
     );
     return this.signaling.connect(authParams, options);
   }
@@ -157,38 +161,45 @@ class BandwidthRtc {
     this.remoteDataChannels.set(streamId, remoteDataChannel);
   }
 
-  private async handleUnsubscribeEvent(notification: SubscriptionEvent) {
+  private handleUnsubscribedEvent(notification: SubscriptionEvent) {
     const streamId = notification.streamId;
-    const rtcPeerConnection = this.remotePeerConnections.get(streamId);
-    if (rtcPeerConnection) {
-      rtcPeerConnection.close();
-    }
-    this.remotePeerConnections.delete(streamId);
-    this.remoteDataChannels.delete(streamId);
+    this.cleanupRemoteStreams(streamId);
     if (this.unsubscribedHandler) {
       this.unsubscribedHandler(notification);
     }
   }
 
-  private async handleUnpublishEvent(notification: UnpublishEvent) {
+  private handleUnpublishedEvent(notification: UnpublishedEvent) {
     const streamId = notification.streamId;
-    await this.unpublish(streamId);
+    this.cleanupLocalStreams(streamId);
+    if (this.unpublishedHandler) {
+      this.unpublishedHandler(notification);
+    }
+  }
+
+  private handleRemovedEvent() {
+    this.cleanupLocalStreams();
+    this.cleanupRemoteStreams();
+    this.signaling.disconnect();
+    if (this.removedHandler) {
+      this.removedHandler();
+    }
   }
 
   onSubscribe(callback: { (event: RtcStream): void }): void {
     this.subscribedHandler = callback;
   }
 
-  onUnsubscribe(callback: { (event: SubscriptionEvent): void }): void {
+  onUnsubscribed(callback: { (event: SubscriptionEvent): void }): void {
     this.unsubscribedHandler = callback;
   }
 
-  onUnpublish(callback: { (event: UnpublishEvent): void }): void {
+  onUnpublished(callback: { (event: UnpublishedEvent): void }): void {
     this.unpublishedHandler = callback;
   }
 
-  onConferenceEnded(callback: { (): void }): void {
-    this.conferenceEndedHandler = callback;
+  onRemoved(callback: { (): void }): void {
+    this.removedHandler = callback;
   }
 
   onMessageReceived(callback: { (message: MessageReceivedEvent): void }): void {
@@ -288,27 +299,49 @@ class BandwidthRtc {
     }
   }
 
-  async unpublish(streamId?: string | string[]) {
-    let streams: string[] = [];
-    if (streamId) {
-      if (typeof streamId === "string") {
-        streams[0] = streamId;
-      } else if (streamId instanceof Array) {
-        streams = streamId;
-      }
-    } else {
+  async unpublish(...streams: string[]) {
+    if (streams.length === 0) {
       streams = Array.from(this.localStreams.keys());
     }
+
     for (const s of streams) {
       await this.signaling.unpublish(s);
+      this.cleanupLocalStreams(s);
+    }
+  }
+
+  private cleanupLocalStreams(...streams: string[]) {
+    if (streams.length === 0) {
+      streams = Array.from(this.localStreams.keys());
+    }
+
+    for (const s of streams) {
       this.stopLocalMedia(s);
       this.localStreams.delete(s);
+
       const localPeerConnection = this.localPeerConnections.get(s);
       localPeerConnection?.close();
       this.localPeerConnections.delete(s);
+
       const localDataChannel = this.localDataChannels.get(s);
       localDataChannel?.close();
       this.localDataChannels.delete(s);
+    }
+  }
+
+  private cleanupRemoteStreams(...streams: string[]) {
+    if (streams.length === 0) {
+      streams = Array.from(this.localStreams.keys());
+    }
+
+    for (const s of streams) {
+      const remotePeerConnection = this.remotePeerConnections.get(s);
+      remotePeerConnection?.close();
+      this.remotePeerConnections.delete(s);
+
+      const remoteDataChannel = this.remoteDataChannels.get(s);
+      remoteDataChannel?.close();
+      this.remoteDataChannels.delete(s);
     }
   }
 

--- a/src/signaling.ts
+++ b/src/signaling.ts
@@ -1,3 +1,5 @@
+//@ts-ignore
+import { version } from "../package.json";
 import { EventEmitter } from "events";
 import { Client as JsonRpcClient } from "rpc-websockets";
 import {
@@ -25,7 +27,7 @@ class Signaling extends EventEmitter {
         rtcOptions = { ...rtcOptions, ...options };
       }
 
-      const websocketUrl = `${rtcOptions.websocketUrl}/v1/?at=d&conferenceId=${authParams.conferenceId}&participantId=${authParams.participantId}`;
+      const websocketUrl = `${rtcOptions.websocketUrl}/v1/?at=d&conferenceId=${authParams.conferenceId}&participantId=${authParams.participantId}&version=${version}`;
 
       const ws = new JsonRpcClient(websocketUrl, {
         max_reconnects: 0 // Unlimited
@@ -33,8 +35,9 @@ class Signaling extends EventEmitter {
       this.ws = ws;
 
       ws.addListener("subscribe", event => this.emit("subscribe", event));
-      ws.addListener("unsubscribe", event => this.emit("unsubscribe", event));
-      ws.addListener("unpublish", event => this.emit("unpublish", event));
+      ws.addListener("unsubscribed", event => this.emit("unsubscribed", event));
+      ws.addListener("unpublished", event => this.emit("unpublished", event));
+      ws.addListener("removed", () => this.emit("removed"));
       ws.addListener("onIceCandidate", event =>
         this.emit("onIceCandidate", event)
       );

--- a/src/signaling.ts
+++ b/src/signaling.ts
@@ -1,5 +1,4 @@
-//@ts-ignore
-import { version } from "../package.json";
+const version = require("../package.json").version;
 import { EventEmitter } from "events";
 import { Client as JsonRpcClient } from "rpc-websockets";
 import {

--- a/src/signaling.ts
+++ b/src/signaling.ts
@@ -1,4 +1,4 @@
-const version = require("../package.json").version;
+const sdkVersion = require("../package.json").version;
 import { EventEmitter } from "events";
 import { Client as JsonRpcClient } from "rpc-websockets";
 import {
@@ -26,7 +26,7 @@ class Signaling extends EventEmitter {
         rtcOptions = { ...rtcOptions, ...options };
       }
 
-      const websocketUrl = `${rtcOptions.websocketUrl}/v1/?at=d&conferenceId=${authParams.conferenceId}&participantId=${authParams.participantId}&version=${version}`;
+      const websocketUrl = `${rtcOptions.websocketUrl}/v1/?at=d&conferenceId=${authParams.conferenceId}&participantId=${authParams.participantId}&sdkVersion=${sdkVersion}`;
 
       const ws = new JsonRpcClient(websocketUrl, {
         max_reconnects: 0 // Unlimited

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface SubscriptionEvent {
   streamId: string;
 }
 
-export interface UnpublishEvent {
+export interface UnpublishedEvent {
   streamId: string;
 }
 


### PR DESCRIPTION
This fixes #4.

Several events were present-tense imperative when they really should have been past-tense declarative. Additionally, this adds a handler for the "removed" event which will clean up all local and remote connections.