### PR TITLE
Remove event listeners on disconnect

### DIFF
--- a/src/bandwidthRtc.ts
+++ b/src/bandwidthRtc.ts
@@ -111,7 +111,7 @@ class BandwidthRtc {
       offerToReceiveAudio: true,
       offerToReceiveVideo: true
     };
-    if (mediaType == MediaType.AUDIO) {
+    if (mediaType === MediaType.AUDIO) {
       offerOptions.offerToReceiveVideo = false;
     }
 

--- a/src/signaling.ts
+++ b/src/signaling.ts
@@ -64,6 +64,7 @@ class Signaling extends EventEmitter {
 
   disconnect() {
     if (this.ws) {
+      this.ws.removeAllListeners();
       this.ws.close();
       this.ws = null;
     }


### PR DESCRIPTION
If the SDK was being used in such a way that there were multiple connects and disconnects on single instance, it would build up additional listeners on each reconnect since it wasn't removing listeners on disconnect. This fixes that problem.