### PR TITLE
v1.0.7 add a separate joinParticipant signal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandwidth/webrtc-browser-sdk",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/webrtc-browser-sdk",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "SDK for Bandwidth WebRTC Browser Applications",
   "main": "dist/index.js",
   "scripts": {

--- a/src/bandwidthRtc.ts
+++ b/src/bandwidthRtc.ts
@@ -17,8 +17,6 @@ const RTC_CONFIGURATION: RTCConfiguration = {
 };
 
 class BandwidthRtc {
-  BandwidthRtc() {}
-
   // Signaling
   private signaling: Signaling = new Signaling();
 
@@ -67,8 +65,16 @@ class BandwidthRtc {
       "unpublished",
       this.handleUnpublishedEvent.bind(this)
     );
-    this.signaling.addListener("removed", this.handleRemovedEvent.bind(this));
-    return this.signaling.connect(authParams, options);
+    this.signaling.addListener(
+      "removed",
+      this.handleRemovedEvent.bind(this)
+    );
+    this.connectAndJoin(authParams, options);
+  }
+
+  private async connectAndJoin(authParams: RtcAuthParams, options?: RtcOptions) {
+    await this.signaling.connect(authParams, options);
+    await this.signaling.join();
   }
 
   private onIceCandidateHandler(event: OnIceCandidateEvent) {

--- a/src/bandwidthRtc.ts
+++ b/src/bandwidthRtc.ts
@@ -69,7 +69,7 @@ class BandwidthRtc {
       "removed",
       this.handleRemovedEvent.bind(this)
     );
-    this.connectAndJoin(authParams, options);
+    return this.connectAndJoin(authParams, options);
   }
 
   private async connectAndJoin(authParams: RtcAuthParams, options?: RtcOptions) {

--- a/src/signaling.ts
+++ b/src/signaling.ts
@@ -4,12 +4,13 @@ import { Client as JsonRpcClient } from "rpc-websockets";
 import {
   RtcAuthParams,
   RtcOptions,
+  JoinResponse,
   SubscribeResponse,
   PublishResponse
 } from "./types";
 
 class Signaling extends EventEmitter {
-  // Websocket
+
   private defaultWebsocketUrl: string = "wss://device.webrtc.bandwidth.com";
   private ws: JsonRpcClient | null = null;
   private pingInterval?: NodeJS.Timeout;
@@ -37,9 +38,7 @@ class Signaling extends EventEmitter {
       ws.addListener("unsubscribed", event => this.emit("unsubscribed", event));
       ws.addListener("unpublished", event => this.emit("unpublished", event));
       ws.addListener("removed", () => this.emit("removed"));
-      ws.addListener("onIceCandidate", event =>
-        this.emit("onIceCandidate", event)
-      );
+      ws.addListener("onIceCandidate", event => this.emit("onIceCandidate", event));
 
       ws.on("open", () => {
         this.pingInterval = setInterval(() => {
@@ -71,6 +70,10 @@ class Signaling extends EventEmitter {
     if (this.pingInterval) {
       clearInterval(this.pingInterval);
     }
+  }
+
+  join(): Promise<JoinResponse> {
+    return this.ws?.call("joinParticipant", {}) as Promise<JoinResponse>;
   }
 
   publish(sdpOffer: string): Promise<PublishResponse> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,9 @@ export interface RtcOptions {
   websocketUrl?: string;
 }
 
+export interface JoinResponse {
+}
+
 export interface SubscribeRequest {
   streamId: string;
   sdpOffer: string;


### PR DESCRIPTION
Tested using serverless-offline locally and sample conference app with upgraded webrtc-browser-sdk.  New request/response and customer notification sent and received.