### PR TITLE
Add support for passing in a custom MediaStream object to the publish function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandwidth/webrtc-browser-sdk",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/webrtc-browser-sdk",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "SDK for Bandwidth WebRTC Browser Applications",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This allows for publishing arbitrary MediaStreams. This opens the door for screen sharing, canvas rendering, audio synthesis and much, much more!