### PR TITLE
Wait until websocket has connected to call joinParticipant (#16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1612,9 +1612,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-            "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+            "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
             "dev": true
         },
         "acorn-globals": {
@@ -5027,9 +5027,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "mixin-deep": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@bandwidth/webrtc-browser-sdk",
-    "version": "1.0.9",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bandwidth/webrtc-browser-sdk",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "SDK for Bandwidth WebRTC Browser Applications",
   "main": "dist/index.js",
   "scripts": {

--- a/src/bandwidthRtc.ts
+++ b/src/bandwidthRtc.ts
@@ -66,15 +66,7 @@ class BandwidthRtc {
 
     this.signaling.addListener("removed", this.handleRemovedEvent.bind(this));
   
-    return this.connectAndJoin(authParams, options);
-  }
-
-  private async connectAndJoin(
-    authParams: RtcAuthParams,
-    options?: RtcOptions
-  ) {
-    await this.signaling.connect(authParams, options);
-    await this.signaling.join();
+    return this.signaling.connect(authParams, options);
   }
 
   private createSignalingBroker() {

--- a/src/signaling.ts
+++ b/src/signaling.ts
@@ -42,10 +42,11 @@ class Signaling extends EventEmitter {
       ws.addListener("removed", () => this.emit("removed"));
       ws.addListener("onIceCandidate", event => this.emit("onIceCandidate", event));
 
-      ws.on("open", () => {
+      ws.on("open", async () => {
         this.pingInterval = setInterval(() => {
           ws.call("onTest", {});
         }, 300000);
+        await this.join();
         resolve();
       });
 
@@ -74,7 +75,7 @@ class Signaling extends EventEmitter {
     }
   }
 
-  join(): Promise<JoinResponse> {
+  private join(): Promise<JoinResponse> {
     return this.ws?.call("joinParticipant", {}) as Promise<JoinResponse>;
   }
 


### PR DESCRIPTION
This fixes #16 

Wait until the websocket has connected (opened) before calling `joinParticipant` to avoid running into "socket not ready" errors.