### PR TITLE
Fix audio sample normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@bandwidth/webrtc-browser-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SDK for Bandwidth WebRTC Browser Applications",
   "main": "dist/index.js",
   "scripts": {
-    "build": "jest && rm -rf ./dist/* && prettier --check  . && ./node_modules/typescript/bin/tsc",
-    "test": "jest --coverage",
-    "test:debug": "node --inspect node_modules/.bin/jest --runInBand --coverage ."
+    "build": "jest src && rm -rf ./dist/* && prettier --check  . && ./node_modules/typescript/bin/tsc",
+    "test": "jest src --coverage",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand --coverage src"
   },
   "repository": {
     "type": "git",

--- a/src/audioLevelDetector.test.ts
+++ b/src/audioLevelDetector.test.ts
@@ -52,7 +52,7 @@ test("test emit low", () => {
     timeThreshold: timeThreshold,
   });
   audioLevelDetector.on("audioLevelChange", spy);
-  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(64)); // LOW
+  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(154)); // LOW
   audioLevelDetector.emitCurrentAudioLevel();
   expect(spy).toHaveBeenCalledWith(AudioLevel.LOW);
 });
@@ -78,7 +78,7 @@ test("test immediate transition from low to high", () => {
     timeThreshold: timeThreshold,
   });
   audioLevelDetector.on("audioLevelChange", spy);
-  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(64)); // LOW
+  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(154)); // LOW
   audioLevelDetector.emitCurrentAudioLevel();
   expect(spy).toHaveBeenCalledWith(AudioLevel.LOW);
   audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(256)); // HIGH
@@ -94,10 +94,10 @@ test("test emit silent after time threshold", async (done) => {
     timeThreshold: timeThreshold,
   });
   audioLevelDetector.on("audioLevelChange", spy);
-  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(64)); // LOW
+  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(154)); // LOW
   audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(256)); // HIGH
   await sleep(timeThreshold + 5);
-  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(0));
+  audioLevelDetector.analyseSample(audioLevelDetector.normalizeSample(128)); // SILENT
   audioLevelDetector.emitCurrentAudioLevel();
   expect(spy).toHaveBeenLastCalledWith(AudioLevel.SILENT);
   done();

--- a/src/audioLevelDetector.ts
+++ b/src/audioLevelDetector.ts
@@ -71,9 +71,16 @@ export default class AudioLevelDetector extends EventEmitter {
     }
   }
 
+  /**
+   * Normalizes the amplitude of Uint8Array audio samples into the range of 0 - 1
+   * Samples are originally in the range of 0-256, where the midpoint of 128 is
+   * silent and the values in either direction are progressively loud, into an
+   * equivalent value between 0 and 1, where 0 is silent and 1 is maximally loud.
+   * @param sample The unsigned integer sample
+   * @returns The amplitude of the audio sample, in the range of 0 - 1
+   */
   normalizeSample(sample: number) {
     // Normalize the sample between 0 - 1
-    // Samples are originally in a Uint8Array so they are 0-256
     // We also need to invert out of phase samples
     return Math.abs(sample / 128 - 1);
   }

--- a/src/audioLevelDetector.ts
+++ b/src/audioLevelDetector.ts
@@ -74,7 +74,8 @@ export default class AudioLevelDetector extends EventEmitter {
   normalizeSample(sample: number) {
     // Normalize the sample between 0 - 1
     // Samples are originally in a Uint8Array so they are 0-256
-    return sample / 256;
+    // We also need to invert out of phase samples
+    return Math.abs(sample / 128 - 1);
   }
 
   analyseSample(normalizedSample: number) {

--- a/src/audioLevelDetector.ts
+++ b/src/audioLevelDetector.ts
@@ -80,8 +80,6 @@ export default class AudioLevelDetector extends EventEmitter {
    * @returns The amplitude of the audio sample, in the range of 0 - 1
    */
   normalizeSample(sample: number) {
-    // Normalize the sample between 0 - 1
-    // We also need to invert out of phase samples
     return Math.abs(sample / 128 - 1);
   }
 


### PR DESCRIPTION
This one line is the real change in this PR:
https://github.com/Bandwidth/webrtc-browser-sdk/compare/speech-detection-fix?expand=1#diff-cc1fbe37a78dc4f941d39135021cf029R78

Audio samples from the Web Audio API are given to us in an Uint8Array, meaning they are values 0-256. Audio recordings have both a positive and negative component to their waveform. This means that a sample of `0` is actually the maximum negative value we can have, so `0` is actually "full volume", rather than silent.

To make things more intuitive for consumers of the `AudioLevelDetector` class, we only present "volume" in the range of 0 - 1. So we want to map "silence" to `0`, and "maximum loudness" to 1. In the case of what we get from the Web Audio API, "silence" is actually `128` and "maximum loudness" is actually `256` _or_ `0`. Both represent maximum amplitude either positive or negative, meaning both sound "loud" to our ears.

Thus, to normalize these samples properly, we first center them on zero by dividing by 128 and subtracting 1. This gives us all the samples in a range of -1 to 1. Taking the absolute value of this, finally gives us the "volume" in the range of 0 - 1 as desired.